### PR TITLE
feat: support per-side stroke weight (strokeTopWeight/strokeBottomWei…

### DIFF
--- a/ReceiveFromMasterGo/code.js
+++ b/ReceiveFromMasterGo/code.js
@@ -937,6 +937,14 @@ function applyProperties(node, data) {
                 safeSet(node, "dashPattern", data.geometry.dashPattern);
             if (data.geometry.strokeCap && !data.connectorFallbackPolyline)
                 safeSet(node, "strokeCap", data.geometry.strokeCap);
+            if (data.geometry.strokeTopWeight !== undefined)
+                safeSet(node, "strokeTopWeight", data.geometry.strokeTopWeight);
+            if (data.geometry.strokeBottomWeight !== undefined)
+                safeSet(node, "strokeBottomWeight", data.geometry.strokeBottomWeight);
+            if (data.geometry.strokeLeftWeight !== undefined)
+                safeSet(node, "strokeLeftWeight", data.geometry.strokeLeftWeight);
+            if (data.geometry.strokeRightWeight !== undefined)
+                safeSet(node, "strokeRightWeight", data.geometry.strokeRightWeight);
         }
         if (data.constraints)
             safeSet(node, "constraints", normalizeConstraints(data.constraints));

--- a/ReceiveFromMasterGo/code.ts
+++ b/ReceiveFromMasterGo/code.ts
@@ -1109,6 +1109,10 @@ async function applyProperties(node: any, data: any) {
     if (data.geometry.strokeJoin) safeSet(node, "strokeJoin", data.geometry.strokeJoin);
     if (data.geometry.dashPattern !== undefined) safeSet(node, "dashPattern", data.geometry.dashPattern);
     if (data.geometry.strokeCap && !data.connectorFallbackPolyline) safeSet(node, "strokeCap", data.geometry.strokeCap);
+    if (data.geometry.strokeTopWeight !== undefined) safeSet(node, "strokeTopWeight", data.geometry.strokeTopWeight);
+    if (data.geometry.strokeBottomWeight !== undefined) safeSet(node, "strokeBottomWeight", data.geometry.strokeBottomWeight);
+    if (data.geometry.strokeLeftWeight !== undefined) safeSet(node, "strokeLeftWeight", data.geometry.strokeLeftWeight);
+    if (data.geometry.strokeRightWeight !== undefined) safeSet(node, "strokeRightWeight", data.geometry.strokeRightWeight);
   }
 
   if (data.constraints) safeSet(node, "constraints", normalizeConstraints(data.constraints));

--- a/SendToFigma/code.js
+++ b/SendToFigma/code.js
@@ -2011,6 +2011,10 @@ function clearNodePaint(nodeJson) {
     nodeJson.geometry.fills = [];
     nodeJson.geometry.strokes = [];
     nodeJson.geometry.strokeWeight = 0;
+    nodeJson.geometry.strokeTopWeight = undefined;
+    nodeJson.geometry.strokeBottomWeight = undefined;
+    nodeJson.geometry.strokeLeftWeight = undefined;
+    nodeJson.geometry.strokeRightWeight = undefined;
 }
 function hasUsableVectorNetwork(vectorNetwork) {
     return !!(vectorNetwork &&
@@ -2483,7 +2487,11 @@ function createFallbackNodeJson(node, sourceType) {
             strokeAlign: "CENTER",
             strokeJoin: "MITER",
             dashPattern: [],
-            strokeCap: "NONE"
+            strokeCap: "NONE",
+            strokeTopWeight: undefined,
+            strokeBottomWeight: undefined,
+            strokeLeftWeight: undefined,
+            strokeRightWeight: undefined
         },
         layout: {
             relativeTransform: layoutTransform,
@@ -3186,6 +3194,10 @@ function getUniversalProperty(selection, sourceType, restoreType) {
             "strokeJoin": readNodeProperty(selection, "strokeJoin", "MITER"),
             "dashPattern": cloneJsonCompatible(readNodeProperty(selection, "strokeDashes", []), []),
             "strokeCap": readNodeProperty(selection, "strokeCap", "NONE"),
+            "strokeTopWeight": ("strokeTopWeight" in selection) ? readNodeProperty(selection, "strokeTopWeight", 0) : undefined,
+            "strokeBottomWeight": ("strokeBottomWeight" in selection) ? readNodeProperty(selection, "strokeBottomWeight", 0) : undefined,
+            "strokeLeftWeight": ("strokeLeftWeight" in selection) ? readNodeProperty(selection, "strokeLeftWeight", 0) : undefined,
+            "strokeRightWeight": ("strokeRightWeight" in selection) ? readNodeProperty(selection, "strokeRightWeight", 0) : undefined,
         },
         "layout": {
             "relativeTransform": layoutTransform,

--- a/SendToFigma/code.ts
+++ b/SendToFigma/code.ts
@@ -2436,6 +2436,10 @@ function clearNodePaint(nodeJson: any) {
     nodeJson.geometry.fills = [];
     nodeJson.geometry.strokes = [];
     nodeJson.geometry.strokeWeight = 0;
+    nodeJson.geometry.strokeTopWeight = undefined;
+    nodeJson.geometry.strokeBottomWeight = undefined;
+    nodeJson.geometry.strokeLeftWeight = undefined;
+    nodeJson.geometry.strokeRightWeight = undefined;
 }
 
 function hasUsableVectorNetwork(vectorNetwork: any) {
@@ -2911,7 +2915,11 @@ function createFallbackNodeJson(node: SceneNode, sourceType?: string) {
             strokeAlign: "CENTER",
             strokeJoin: "MITER",
             dashPattern: [],
-            strokeCap: "NONE"
+            strokeCap: "NONE",
+            strokeTopWeight: undefined,
+            strokeBottomWeight: undefined,
+            strokeLeftWeight: undefined,
+            strokeRightWeight: undefined
         },
         layout: {
             relativeTransform: layoutTransform,
@@ -3662,6 +3670,10 @@ function getUniversalProperty(selection: SceneNode, sourceType?: string, restore
             "strokeJoin": readNodeProperty(selection, "strokeJoin", "MITER"),
             "dashPattern": cloneJsonCompatible(readNodeProperty<any[]>(selection, "strokeDashes", []), []),
             "strokeCap": readNodeProperty(selection, "strokeCap", "NONE"),
+            "strokeTopWeight": ("strokeTopWeight" in (selection as any)) ? readNodeProperty(selection, "strokeTopWeight", 0) : undefined,
+            "strokeBottomWeight": ("strokeBottomWeight" in (selection as any)) ? readNodeProperty(selection, "strokeBottomWeight", 0) : undefined,
+            "strokeLeftWeight": ("strokeLeftWeight" in (selection as any)) ? readNodeProperty(selection, "strokeLeftWeight", 0) : undefined,
+            "strokeRightWeight": ("strokeRightWeight" in (selection as any)) ? readNodeProperty(selection, "strokeRightWeight", 0) : undefined,
         },
         "layout": {
             "relativeTransform": layoutTransform,


### PR DESCRIPTION
## 功能说明

支持导出和还原容器/矩形单边描边宽度属性（strokeTopWeight / strokeBottomWeight / strokeLeftWeight / strokeRightWeight）。

### 改动内容

**SendToFigma（MasterGo 发送端）**
- getUniversalProperty() 中新增读取四个方向的独立描边宽度，仅对拥有 RectangleStrokeWeightMixin 的节点（Frame、Rectangle、Section、Component、ComponentSet、Instance）导出实际值，不支持单边描边的节点导出 undefined
- 默认 geometry 对象和 clearNodePaint() 中同步添加四个属性

**ReceiveFromMasterGo（Figma 接收端）**
- 还原时通过 safeSet 写入四个方向描边宽度，!== undefined 检查确保向后兼容旧版导出的 zip

### 兼容性
- 统一描边宽度（strokeWeight）保持不变，正常导出和还原
- 旧版 zip（无单边描边字段）不受影响
- 不支持单边描边的节点（Ellipse、Star 等）导出 undefined，接收端自动跳过
